### PR TITLE
Added sensor enable directives and rebuilt sensor data printout

### DIFF
--- a/AP-Home.ino
+++ b/AP-Home.ino
@@ -2,9 +2,6 @@
 #include "AP_Nurse.h"
 #include "ClickButton.h"
 
-//uncommenting the next line disables PIR sensor update
-//#define _DISABLE_PIR
-
 //uncommenting next line enables buzzer
 //#define _BUZZER
 

--- a/AP_Nurse.cpp
+++ b/AP_Nurse.cpp
@@ -6,10 +6,14 @@ PCF8591 extender(0, false);
  */
 AP_Nurse::AP_Nurse(){
     //I/O init
-    #ifdef _PIR_ENABLE
+    #ifdef PIR_ENABLE
     pinMode(PIR_PIN, INPUT);
     #endif
+
+    #ifdef NOISE_ENABLE
     pinMode(NOISE_PIN, INPUT);
+    #endif
+
     pinMode(DAY_NIGHT, INPUT);
     pinMode(TE, OUTPUT);
     pinMode(ENCODER_PIN, OUTPUT);
@@ -59,20 +63,22 @@ uint8_t AP_Nurse::getLastPressure(){
 
 void AP_Nurse::printData(){
     Serial.println();
-    Serial.print("Motion:    ");
-    Serial.println(this -> getLastMotion());
-    Serial.print("Noise:     ");
-    Serial.println(this -> getLastNoise());
-    Serial.print("Smoke:     ");
-    Serial.println(this -> getLastSmoke());
-    Serial.print("Gas:       ");
-    Serial.println(this -> getLastGas());
-    Serial.print("Light:     ");
-    Serial.println(this -> getLastLight());
-    Serial.print("Pressure:  ");
-    Serial.println(this -> getLastPressure());
-    Serial.print("Button:    ");
-    Serial.println(digitalRead(BUTTON_PIN));
+
+    #ifdef PIR_ENABLE
+    Serial.printf("Motion:      %d\r\n", this -> getLastMotion());
+    #endif
+
+    #ifdef NOISE_ENABLE
+    Serial.printf("Noise:       %d\r\n", this -> getLastNoise());
+    #endif
+
+    #ifdef EXTENDER_ENABLE
+    Serial.printf("Smoke:       %d\r\n", this -> getLastSmoke());
+    Serial.printf("Gas:         %d\r\n", this -> getLastGas());
+    Serial.printf("Light:       %d\r\n", this -> getLastLight());
+    Serial.printf("Pressure:    %d\r\n", this -> getLastPressure());
+    #endif
+    Serial.printf("Button:      %d\r\n", digitalRead(BUTTON_PIN));
 }
 
 status_t AP_Nurse::checkMotion(){
@@ -167,16 +173,20 @@ uint8_t AP_Nurse_Hallway::update(){
 /** AP_nurse_Universal methods definitions
  */
 uint8_t AP_Nurse_Universal::update(){
-    #ifdef _PIR_ENABLE
+    #ifdef PIR_ENABLE
     this -> checkMotion();
     #endif
+
+    #ifdef NOISE_ENABLE
     this -> checkNoise();
-    //this -> checkTemperature();
-    //this -> checkExtender();
+    #endif
+
+    #ifdef EXTENDER_ENABLE
     if((millis() - this -> ap_node.lastEcheck) >= 5000){
         this -> checkExtender();
         this -> ap_node.lastEcheck = millis();
     }
+    #endif
 
     return this -> ap_node.lastAlert;
 }

--- a/AP_Nurse.h
+++ b/AP_Nurse.h
@@ -5,6 +5,7 @@
 #include <Wire.h>
 #include "AP_Nurse_types.h"
 #include "AP_Nurse_Home_Pinout.h"
+#include "Sensor_enable.h"
 #include "PCF8591.h"
 
 class AP_Nurse{

--- a/Sensor_enable.h
+++ b/Sensor_enable.h
@@ -5,6 +5,8 @@
  * 
  *  @note uncommenting any of the following results in disabling respective sensor reading
  */
-#define _PIR_ENABLE
+#define PIR_ENABLE
+#define NOISE_ENABLE
+#define EXTENDER_ENABLE
 
 #endif


### PR DESCRIPTION
Added `_ENABLE` directives for PIR, noise and analog extender sensors.